### PR TITLE
Add high-performance parser in `dns::hp`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@
 A DNS library for the [Rust](http://rust-lang.org) language.
 
 Sample client code is located in `src/bin/testclient.rs`. There is currently no write support, so it sends a captured sample packet doing a recursive `A`-record lookup for `facebook.com`, parses the response, and prints out an `fmt::Show` view of the response.
+
+There are currently two implementations in the library.
+
+## `dns::hp`
+Minimal-allocation DNS packet parsing code. With ~500 byte packets (i.e., nameservers and glue records for the .com TLD), the rudimentary benchmark in `src/bin/benchmark.rs` it can handle about 160,000 packets per second with 4 threads on a quad-cord 2012 Retina MacBook Pro.
+
+This implementation is very narrowly architected for fast parsing, and has no support for constructing packets.
+
+## `dns::msg`
+General-purpose DNS packet parsing and representation. Designed to support both parsing and construction of DNS queries and responses.

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -1,0 +1,29 @@
+#![allow(dead_code,unused_imports,unused_must_use,unused_assignments)]
+
+extern crate dns;
+
+use std::io::net::udp::UdpSocket;
+use std::io::net::ip::{Ipv4Addr, SocketAddr};
+use std::io::BufReader;
+use std::rand;
+
+//use dns::msg::{DNSMessageReader,Message};
+//use dns::msg::record::{Question,ResourceRecord};
+//use dns::number;
+
+use dns::hp::read_dns_message;
+
+fn main() {
+    let buf = include_bin!("../../tests/packets/net1-rs.bin");
+    let npr = 4i;
+    for _ in range(0, npr) {
+        spawn(move || {
+            for i in range(0, 1000000i / npr) {
+                let buf2 = buf.clone();
+                let m = read_dns_message(buf2).ok().unwrap();
+                m.id;
+                if i % 1000 == 0 { println!("completed {}",i); }
+            }
+        });
+    }
+}

--- a/src/hp/mod.rs
+++ b/src/hp/mod.rs
@@ -1,0 +1,251 @@
+pub use super::number::types::Type;
+pub use super::number::classes::Class;
+pub use super::number::rcodes::RCode;
+pub use super::number::opcodes::OpCode;
+pub use super::number::errors::IdentifierError;
+
+use std::io;
+use std::str;
+use std::fmt;
+
+use self::util::{_read_be_u16,_read_be_i32};
+
+mod util;
+
+#[deriving(PartialEq,Show,Clone)]
+pub struct Message<'n> {
+    pub id: u16,
+    pub flags: u16,
+    pub questions: Vec<Question<'n>>,
+    pub answers: Vec<ResourceRecord<'n>>,
+    pub nameservers: Vec<ResourceRecord<'n>>,
+    pub additionals: Vec<ResourceRecord<'n>>,
+}
+
+#[deriving(PartialEq,Show,Clone)]
+pub struct Question<'n> {
+    pub qname: Name<'n>,
+    pub qtype: Type,
+    pub qclass: Class,
+}
+
+#[deriving(PartialEq,Show,Clone)]
+pub struct ResourceRecord<'n> {
+    pub rname: Name<'n>,
+    pub rtype: Type,
+    pub rclass: Class,
+    pub rttl: i32,
+    pub rdlen: u16,
+    pub rdata: uint,
+    pub context: &'n [u8],
+}
+
+#[deriving(PartialEq,Eq,Hash,Clone)]
+pub struct Name<'n> {
+    labels: Vec<&'n str>,
+}
+impl<'n> Name<'n> {
+    #[inline]
+    pub fn to_string(&self) -> String {
+        format!("{}.", self.labels.connect("."))
+    }
+    pub fn from_rdata<'r>(rr: &'r ResourceRecord) -> io::IoResult<Name<'r>> {
+        let mut i = rr.rdata;
+        read_dns_name(rr.context, &mut i)
+    }
+}
+impl<'n> fmt::Show for Name<'n> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}
+
+pub fn read_dns_message<'b>(buf: &'b [u8]) -> io::IoResult<Message<'b>> {
+    if buf.len() < 12 { return Err(io::standard_error(io::InvalidInput)); }
+    let mut i = 0u;
+    let id = _read_be_u16(buf, &mut i);
+    let flags = _read_be_u16(buf, &mut i);
+    let qdcount = _read_be_u16(buf, &mut i);
+    let ancount = _read_be_u16(buf, &mut i);
+    let nscount = _read_be_u16(buf, &mut i);
+    let adcount = _read_be_u16(buf, &mut i);
+    
+    let mut msg = Message {
+        id: id,
+        flags: flags,
+        questions: Vec::new(),
+        answers: Vec::new(),
+        nameservers: Vec::new(),
+        additionals: Vec::new(),
+    };
+
+
+    for n in range(0, qdcount) { msg.questions.push(try!(read_dns_question(buf, &mut i))) }
+    for n in range(0, ancount) { msg.answers.push(try!(read_dns_resource_record(buf, &mut i))) }
+    for n in range(0, nscount) { msg.nameservers.push(try!(read_dns_resource_record(buf, &mut i))) }
+    for n in range(0, adcount) { msg.additionals.push(try!(read_dns_resource_record(buf, &mut i))) }
+
+    
+    Ok(msg)
+}
+
+fn read_dns_question<'b>(buf: &'b [u8], idx: &mut uint) -> io::IoResult<Question<'b>> {
+    let q = Question {
+        qname: try!(read_dns_name(buf, idx)),
+        qtype: match Type::from_u16(_read_be_u16(buf, idx)) {
+            Ok(val) => val,
+            Err(_) => return Err(io::standard_error(io::InvalidInput)),
+        },
+        qclass: match Class::from_u16(_read_be_u16(buf, idx)) {
+            Ok(val) => val,
+            Err(_) => return Err(io::standard_error(io::InvalidInput)),
+        },
+    };
+    Ok(q)
+}
+
+fn read_dns_resource_record<'b>(buf: &'b [u8], idx: &mut uint) -> io::IoResult<ResourceRecord<'b>> {
+    let mut r = ResourceRecord {
+        rname: try!(read_dns_name(buf, idx)),
+        rtype: match Type::from_u16(_read_be_u16(buf, idx)) {
+            Ok(val) => val,
+            Err(_) => return Err(io::standard_error(io::InvalidInput)),
+        },
+        rclass: match Class::from_u16(_read_be_u16(buf, idx)) {
+            Ok(val) => val,
+            Err(_) => return Err(io::standard_error(io::InvalidInput)),
+        },
+        rttl: _read_be_i32(buf, idx),
+        rdlen: _read_be_u16(buf, idx),
+        rdata: *idx,
+        context: buf,
+    };
+    *idx += (r.rdlen as uint);
+    Ok(r)
+}
+
+fn read_dns_name<'b>(buf: &'b [u8], idx: &mut uint) -> io::IoResult<Name<'b>> {
+
+    let mut labels: Vec<&str> = Vec::with_capacity(8);
+
+    let mut follow = false;
+    let mut return_to = 0u;
+    // Read in labels
+    loop {
+        // Get the next label's size
+        let llen = buf[*idx];
+
+        if llen == 0 {
+            // Zero length labels are the root, so we're done
+
+            break;
+        } else if (llen & 0xC0) == 0xC0 {
+            // Labels with the two high order bits set (0xC0)
+            // are pointers.
+
+            // If this is the first pointer encountered, store
+            // the current reader location to restore later.
+            if !follow {
+                return_to = *idx+2;
+                follow = true;
+            }
+
+            // Seek to the pointer location
+            *idx = buf[*idx+1] as uint;
+            continue;
+        } else {
+            let offset = 1 + (llen as uint);
+            let str_read = str::from_utf8(buf[*idx+1..*idx+offset]);
+            *idx += offset;
+            match str_read {
+                Some(s) => {
+                    labels.push(s);
+                },
+                None => return Err(io::standard_error(io::InvalidInput)),
+            }
+        }
+    }
+
+    if follow {
+        // Restore the reader location to the byte after the first
+        // pointer followed during the read.
+        *idx = return_to;
+    } else {
+        // Or just push the index up by one if we aren't reading.
+        *idx += 1;
+    }
+
+    Ok(Name { labels: labels })
+}
+
+#[cfg(test)]
+mod test_hp {
+    
+    use super::read_dns_message;
+    use super::Message;
+    use super::Name;
+    static NET1_RS: &'static [u8] = include_bin!("../../tests/packets/net1-rs.bin");
+
+    fn check_std_query_recursive(m: &Message) {
+        assert_eq!(m.flags, 0x0100);
+        assert_eq!(m.questions.len(), 1);
+        assert_eq!(m.answers.len(), 0);
+        assert_eq!(m.nameservers.len(), 0);
+        assert_eq!(m.additionals.len(), 0);
+    }
+    fn check_std_query_norecurse(m: &Message) {
+        assert_eq!(m.flags, 0x0000);
+        assert_eq!(m.questions.len(), 1);
+        assert_eq!(m.answers.len(), 0);
+        assert_eq!(m.nameservers.len(), 0);
+        assert_eq!(m.additionals.len(), 0);
+    }
+    fn check_std_response_recursive(m: &Message, q: uint, a: uint, n: uint, x: uint) {
+        assert_eq!(m.flags, 0x8180);
+        assert_eq!(m.questions.len(), q);
+        assert_eq!(m.answers.len(), a);
+        assert_eq!(m.nameservers.len(), n);
+        assert_eq!(m.additionals.len(), x);
+    }
+    fn check_std_response_norecurse(m: &Message, q: uint, a: uint, n: uint, x: uint) {
+        assert_eq!(m.flags, 0x8000);
+        assert_eq!(m.questions.len(), q);
+        assert_eq!(m.answers.len(), a);
+        assert_eq!(m.nameservers.len(), n);
+        assert_eq!(m.additionals.len(), x);
+    }
+
+    #[test]
+    fn test_read_dns_message() {
+        let m = match read_dns_message(NET1_RS) {
+            Ok(x) => x,
+            Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+        };
+        assert_eq!(m.id, 0xe1c9);
+        assert_eq!(m.flags, 0x8000);
+
+        let q = m.questions[0].clone();
+        assert_eq!(format!("{}",q.qname).as_slice(), "net.");
+        check_std_response_norecurse(&m, 1, 0, 13, 15);
+        let mut a_ct: uint = 0;
+        for a in m.nameservers.iter() {
+            assert_eq!(a.rttl, 172800);
+            
+            let n = Name::from_rdata(a).ok().unwrap().to_string();
+            if n.as_slice() == "a.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "b.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "c.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "d.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "e.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "f.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "g.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "h.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "i.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "j.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "k.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "l.gtld-servers.net." { a_ct += 1; }
+            if n.as_slice() == "m.gtld-servers.net." { a_ct += 1; }
+        }
+        assert_eq!(a_ct, 13);
+    }
+}

--- a/src/hp/util.rs
+++ b/src/hp/util.rs
@@ -1,0 +1,32 @@
+#[inline(always)]
+pub fn _read_be_u16(buf: &[u8], idx: &mut uint) -> u16 {
+    let out: u16 = ((buf[*idx] as u16) << 8) + (buf[*idx+1] as u16);
+    *idx += 2;
+    out
+}
+#[inline(always)]
+pub fn _read_be_i32(buf: &[u8], idx: &mut uint) -> i32 {
+    let out: i32 = ((buf[*idx] as i32) << 24) + ((buf[*idx+1] as i32) << 16) + ((buf[*idx+2] as i32) << 8) + ((buf[*idx+3] as i32));
+    *idx += 4;
+    out
+}
+
+#[cfg(test)]
+mod test_hp_support_functions {
+    #[test]
+    fn test_read_be_u16() {
+        for i in range(0, 65536u) {
+            let b = [((i & 0xFF00) >> 8) as u8, (i & 0x00FF) as u8];
+            assert_eq!(super::_read_be_u16(&b, &mut 0), i as u16);
+        }
+    }
+    #[test]
+    #[allow(overflowing_literals)]
+    fn test_read_be_i32() {
+        let test_vals = vec!(-2147483648i32,-20000000, -1, 0, 1, 20000000, 2147483647i32);
+        for &i in test_vals.iter() {
+            let b = [((i & 0xFF000000) >> 24) as u8, ((i & 0xFF0000) >> 16) as u8, ((i & 0xFF00) >> 8) as u8, (i & 0x00FF) as u8];
+            assert_eq!(super::_read_be_i32(&b, &mut 0), i as i32);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(slicing_syntax)]
 #![allow(unused_variables)]
 //#![allow(dead_code)]
 #![allow(unused_mut)]
@@ -5,3 +6,4 @@
 pub mod number;
 pub mod msg;
 pub mod name;
+pub mod hp;

--- a/src/number/classes.rs
+++ b/src/number/classes.rs
@@ -1,7 +1,7 @@
 pub use super::IdentifierError;
 
 #[repr(u16)]
-#[deriving(PartialEq,Show,Clone)]
+#[deriving(PartialEq,Show,Copy,Clone)]
 pub enum Class {
     IN = 1,
     CH = 3,

--- a/src/number/edns0codes.rs
+++ b/src/number/edns0codes.rs
@@ -1,7 +1,7 @@
 pub use super::IdentifierError;
 
 #[repr(u16)]
-#[deriving(PartialEq,Show,Clone)]
+#[deriving(PartialEq,Show,Copy,Clone)]
 pub enum EDNS0OptionCode {
     LLQ = 1,
     UL = 2,

--- a/src/number/errors.rs
+++ b/src/number/errors.rs
@@ -1,6 +1,6 @@
 use std::error;
 
-#[deriving(PartialEq,Show,Clone)]
+#[deriving(PartialEq,Show,Copy,Clone)]
 pub enum IdentifierError {
 	ReservedIdentifierError(i64),
 	UnassignedIdentifierError(i64),

--- a/src/number/opcodes.rs
+++ b/src/number/opcodes.rs
@@ -1,7 +1,7 @@
 pub use super::IdentifierError;
 
 #[repr(u8)]
-#[deriving(PartialEq,Show,Clone)]
+#[deriving(PartialEq,Show,Copy,Clone)]
 pub enum OpCode {
     Query = 0,
     IQuery = 1,

--- a/src/number/rcodes.rs
+++ b/src/number/rcodes.rs
@@ -1,7 +1,7 @@
 pub use super::IdentifierError;
 
 #[repr(u16)]
-#[deriving(PartialEq,Show,Clone)]
+#[deriving(PartialEq,Show,Copy,Clone)]
 pub enum RCode {
     NoError = 0,
     FormErr = 1,

--- a/src/number/types.rs
+++ b/src/number/types.rs
@@ -1,7 +1,7 @@
 pub use super::IdentifierError;
 
 #[repr(u16)]
-#[deriving(PartialEq,Show,Clone)]
+#[deriving(PartialEq,Show,Copy,Clone)]
 pub enum Type {
     A = 1,
     NS = 2,

--- a/tests/test_messages.rs
+++ b/tests/test_messages.rs
@@ -2,9 +2,15 @@
 
 extern crate dns;
 
-use dns::msg::{Message,DNSMessageReader,Name};
+use dns::hp::{Message,Name,read_dns_message};
 
 use std::io;
+
+static NET1_RS: &'static [u8] = include_bin!("packets/net1-rs.bin");
+static NET1_RQ: &'static [u8] = include_bin!("packets/net1-rq.bin");
+static FB1_RS: &'static [u8] = include_bin!("packets/fb1-rs.bin");
+static FB1_RQ: &'static [u8] = include_bin!("packets/fb1-rq.bin");
+static COMNS1_RS: &'static [u8] = include_bin!("packets/comns1-rs.bin");
 
 fn check_std_query_recursive(m: &Message) {
     assert_eq!(m.flags, 0x0100);
@@ -37,33 +43,59 @@ fn check_std_response_norecurse(m: &Message, q: uint, a: uint, n: uint, x: uint)
 
 #[test]
 fn test_parse_fb1_rq() {
-    let rq = include_bin!("packets/fb1-rq.bin");
-    let m = Message::from_buf(rq).ok().unwrap();
+    let m = match read_dns_message(FB1_RQ) {
+        Ok(x) => x,
+        Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+    };
     assert_eq!(m.id, 0x0b8d);
     check_std_query_recursive(&m);
 }
 #[test]
 fn test_parse_fb1_rs() {
-    let rs = include_bin!("packets/fb1-rs.bin");
-    let m = Message::from_buf(rs).ok().unwrap();
+    let m = match read_dns_message(FB1_RS) {
+        Ok(x) => x,
+        Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+    };
     assert_eq!(m.id, 0x0b8d);
     check_std_response_recursive(&m, 1, 1, 0, 0);
 }
 
 #[test]
 fn test_parse_comns1_rs() {
-    let rs = include_bin!("packets/comns1-rs.bin");
-    let mut r = io::BufReader::new(rs);
-    let m = r.read_dns_message().ok().unwrap();
+    let m = match read_dns_message(COMNS1_RS) {
+        Ok(x) => x,
+        Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+    };
     assert_eq!(m.id, 0x363a);
     check_std_response_norecurse(&m, 1, 0, 13, 14);
+    let mut a_ct: uint = 0;
+    for a in m.nameservers.iter() {
+        assert_eq!(a.rttl, 172800);
+        
+        let n = Name::from_rdata(a).ok().unwrap().to_string();
+        if n.as_slice() == "a.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "b.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "c.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "d.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "e.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "f.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "g.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "h.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "i.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "j.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "k.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "l.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "m.gtld-servers.net." { a_ct += 1; }
+    }
+    assert_eq!(a_ct, 13);
 }
 
 #[test]
 fn test_parse_net1_rq() {
-    let rq = include_bin!("packets/net1-rq.bin");
-    let mut r = io::BufReader::new(rq);
-    let m = r.read_dns_message().ok().unwrap();
+    let m = match read_dns_message(NET1_RQ) {
+        Ok(x) => x,
+        Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+    };
 
     assert_eq!(m.id, 0xe1c9);
     check_std_query_norecurse(&m);
@@ -71,30 +103,34 @@ fn test_parse_net1_rq() {
 
 #[test]
 fn test_parse_net1_rs() {
-    let rs = include_bin!("packets/net1-rs.bin");
-    let mut r = io::BufReader::new(rs);
-    let m = r.read_dns_message().ok().unwrap();
-
+    let m = match read_dns_message(NET1_RS) {
+        Ok(x) => x,
+        Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+    };
     assert_eq!(m.id, 0xe1c9);
-    check_std_response_norecurse(&m, 1, 0, 13, 15);
+    assert_eq!(m.flags, 0x8000);
+
     let q = m.questions[0].clone();
     assert_eq!(format!("{}",q.qname).as_slice(), "net.");
+    check_std_response_norecurse(&m, 1, 0, 13, 15);
     let mut a_ct: uint = 0;
     for a in m.nameservers.iter() {
-        let n = Name::parse_decompressed(a.rdata.as_slice()).ok().unwrap();
-        if format!("{}",n).as_slice() == "a.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "b.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "c.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "d.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "e.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "f.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "g.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "h.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "i.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "j.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "k.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "l.gtld-servers.net." { a_ct += 1; }
-        if format!("{}",n).as_slice() == "m.gtld-servers.net." { a_ct += 1; }
+        assert_eq!(a.rttl, 172800);
+        
+        let n = Name::from_rdata(a).ok().unwrap().to_string();
+        if n.as_slice() == "a.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "b.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "c.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "d.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "e.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "f.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "g.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "h.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "i.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "j.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "k.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "l.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "m.gtld-servers.net." { a_ct += 1; }
     }
     assert_eq!(a_ct, 13);
 }


### PR DESCRIPTION
Implements a brand-new high-performance RFC1035 parser in
`dns::hp`. Existing implementation in `dns::msg` still useful
as noted in README.md update.
