### PR TITLE
Convert labels in `dns::hp` from &str to new `Label` type.

### DIFF
--- a/src/bin/test_fuzz.rs
+++ b/src/bin/test_fuzz.rs
@@ -28,9 +28,9 @@ fn main() {
     // Use random seed for actual binary
     let mut rng: StdRng = StdRng::new().ok().unwrap();
     rand_buf(buf.as_mut_slice(), &mut rng);
-    do_fuzz(buf.as_slice(), &mut rng, 10000000u);
+    do_fuzz(buf.as_slice(), &mut rng, 1000000u);
     let pkt = include_bin!("../../tests/packets/net1-rs.bin");
-    do_fuzz_rewrite(pkt, buf.as_mut_slice(), &mut rng, 200000u);
+    do_fuzz_rewrite(pkt, buf.as_mut_slice(), &mut rng, 1000000u);
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn test_dns_hp_fuzzing() {
     let seed: &[_] = &[508, 53, 284, 224, 173, 23, 572, 634, 439, 983];
     let mut rng: StdRng = SeedableRng::from_seed(seed);
     rand_buf(buf.as_mut_slice(), &mut rng);
-    do_fuzz(buf.as_slice(), &mut rng, 1000000u);
+    do_fuzz(buf.as_slice(), &mut rng, 10000u);
 }
 
 #[test]
@@ -51,7 +51,7 @@ fn test_dns_hp_fuzzing_rewrite() {
     let seed: &[_] = &[508, 53, 284, 224, 173, 23, 572, 634, 439, 983];
     let mut rng: StdRng = SeedableRng::from_seed(seed);
     rand_buf(buf.as_mut_slice(), &mut rng);
-    do_fuzz_rewrite(pkt, buf.as_mut_slice(), &mut rng, 100000u);
+    do_fuzz_rewrite(pkt, buf.as_mut_slice(), &mut rng, 10000u);
 }
 
 fn rand_buf(buf: &mut [u8], rng: &mut StdRng) {
@@ -100,7 +100,7 @@ fn do_fuzz_rewrite(pkt: &[u8], buf: &[u8], rng: &mut StdRng, iters: uint) {
     let end = time::precise_time_ns();
     let elapsed = (end - start) as f64 / 1000000000.;
     let avg_size = (tsz) as f64 / iters as f64;
-    println!("Fuzz: completed {} iterations in {}s ({} ok/{} err/rw {} byte avg)", iters, elapsed, oks, errs, avg_size);
+    println!("Fuzz-RW: completed {} iterations in {}s ({} ok/{} err/rw {} byte avg)", iters, elapsed, oks, errs, avg_size);
 }
 
 fn do_fuzz(buf: &[u8], rng: &mut StdRng, iters: uint) {

--- a/src/hp/err.rs
+++ b/src/hp/err.rs
@@ -7,6 +7,7 @@ pub enum ReadError {
     IndexOutOfRangeError(uint, uint),
     LabelTooLongError(uint),
     LabelZeroLengthError,
+    LabelInputFormatError,
 }
 
 impl error::Error for ReadError {
@@ -15,7 +16,8 @@ impl error::Error for ReadError {
             ReadError::InvalidIdentifierError(x) => "Read an invalid identifier",
             ReadError::IndexOutOfRangeError(_, _) => "Index out of range",
             ReadError::LabelTooLongError(x) => "Label too long",
-            ReadError::LabelZeroLengthError => "Label has zero length"
+            ReadError::LabelZeroLengthError => "Label has zero length",
+            ReadError::LabelInputFormatError => "Label input format invalid",
         }
     }
 
@@ -25,6 +27,7 @@ impl error::Error for ReadError {
             ReadError::IndexOutOfRangeError(x, y) => Some(format!("Index out of range: {} > {}", x, y)),
             ReadError::LabelTooLongError(x) => Some(format!("Label was too long: {} > 63", x)),
             ReadError::LabelZeroLengthError => Some(format!("Label has zero length")),
+            ReadError::LabelInputFormatError => Some(format!("Label input format invalid")),
 
         }
     }

--- a/src/hp/err.rs
+++ b/src/hp/err.rs
@@ -5,7 +5,8 @@ use super::IdentifierError;
 pub enum ReadError {
     InvalidIdentifierError(super::IdentifierError),
     IndexOutOfRangeError(uint, uint),
-    InvalidUTF8StringError,
+    LabelTooLongError(uint),
+    LabelZeroLengthError,
 }
 
 impl error::Error for ReadError {
@@ -13,7 +14,8 @@ impl error::Error for ReadError {
         match *self {
             ReadError::InvalidIdentifierError(x) => "Read an invalid identifier",
             ReadError::IndexOutOfRangeError(_, _) => "Index out of range",
-            ReadError::InvalidUTF8StringError => "Invalid UTF-8 string",
+            ReadError::LabelTooLongError(x) => "Label too long",
+            ReadError::LabelZeroLengthError => "Label has zero length"
         }
     }
 
@@ -21,7 +23,9 @@ impl error::Error for ReadError {
         match *self {
             ReadError::InvalidIdentifierError(x) => Some(format!("Read an invalid identifier: {}", x)),
             ReadError::IndexOutOfRangeError(x, y) => Some(format!("Index out of range: {} > {}", x, y)),
-            ReadError::InvalidUTF8StringError => Some(format!("Invalid UTF-8 string")),
+            ReadError::LabelTooLongError(x) => Some(format!("Label was too long: {} > 63", x)),
+            ReadError::LabelZeroLengthError => Some(format!("Label has zero length")),
+
         }
     }
 

--- a/src/hp/tests.rs
+++ b/src/hp/tests.rs
@@ -1,0 +1,103 @@
+use super::read_dns_message;
+use super::{Message,Name,Label};
+static NET1_RS: &'static [u8] = include_bin!("../../tests/packets/net1-rs.bin");
+
+fn check_std_response_norecurse(m: &Message, q: uint, a: uint, n: uint, x: uint) {
+    assert_eq!(m.flags, 0x8000);
+    assert_eq!(m.questions.len(), q);
+    assert_eq!(m.answers.len(), a);
+    assert_eq!(m.nameservers.len(), n);
+    assert_eq!(m.additionals.len(), x);
+}
+
+#[test]
+fn test_label_create() {
+    // Maximum label length is 63 octets
+    let l63 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+    let l64 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
+    let l0 = "".as_bytes();
+    assert!(Label::from_slice(l63).is_ok());
+    assert!(Label::from_slice(l64).is_err());
+}
+
+#[test]
+fn test_label_eq() {
+    let l1 = Label::from_slice("cat".as_bytes()).ok().unwrap();
+    let l2 = Label::from_slice("Cat".as_bytes()).ok().unwrap();
+    let l3 = Label::from_slice("CAT".as_bytes()).ok().unwrap();
+    let l4 = Label::from_slice("cat1".as_bytes()).ok().unwrap();
+    let l5 = Label::from_slice("cat2".as_bytes()).ok().unwrap();
+    let l6 = Label::from_slice("Cat1".as_bytes()).ok().unwrap();
+    
+    // Case insensitivity tests
+    assert_eq!(l1, l2);
+    assert_eq!(l2, l3);
+    assert_eq!(l1, l3);
+    assert_eq!(l4, l6);
+
+    // Basic inequality tests
+    assert!(l4 != l5);
+    assert!(l5 != l6);
+
+    let mut b1 = [0x63u8, 0x61, 0x74, 0x31];
+    let mut b2 = [0x63u8, 0x61, 0x74, 0x31];
+    for i in range(0, 256u) {
+        let x = i as u8;
+        let y = if x > 0 { x - 1 } else { 255 };
+        b1[3] = x;
+        b2[3] = y;
+        assert!(Label::from_slice(&b1) != Label::from_slice(&b2));
+        b2[3] = x;
+        assert!(Label::from_slice(&b1) == Label::from_slice(&b2));
+    }
+}
+#[test]
+fn test_label_ord() {
+    let l1 = Label::from_slice("Cat1".as_bytes()).ok().unwrap();
+    let l2 = Label::from_slice("cat1".as_bytes()).ok().unwrap();
+    let l3 = Label::from_slice("cat2".as_bytes()).ok().unwrap();
+
+    // Test ordering (DNSSEC canonical)
+    assert!(l1 < l2);
+    assert!(l2 < l3);
+    assert!(l1 < l3);
+}
+
+#[test]
+fn test_read_dns_message() {
+    let m = match read_dns_message(NET1_RS) {
+        Ok(x) => x,
+        Err(e) => { println!("err: {}",e); panic!("FAIL"); },
+    };
+    assert_eq!(m.id, 0xe1c9);
+    assert_eq!(m.flags, 0x8000);
+
+    let q = m.questions[0].clone();
+    assert_eq!(format!("{}",q.qname).as_slice(), "net.");
+    check_std_response_norecurse(&m, 1, 0, 13, 15);
+    let mut a_ct: uint = 0;
+    for a in m.nameservers.iter() {
+        assert_eq!(a.rttl, 172800);
+        
+        let n = Name::from_rdata(a).ok().unwrap().to_string();
+        if n.as_slice() == "a.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "b.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "c.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "d.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "e.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "f.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "g.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "h.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "i.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "j.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "k.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "l.gtld-servers.net." { a_ct += 1; }
+        if n.as_slice() == "m.gtld-servers.net." { a_ct += 1; }
+    }
+    assert_eq!(a_ct, 13);
+}
+
+#[test]
+fn test_bounds_checks() {
+    let m = read_dns_message(NET1_RS[0..NET1_RS.len()-2]).err();
+}


### PR DESCRIPTION
New `Label` type using &[u8] as the internal representation.
### Requirements
- [ ] Full RFC 1035 compliance
- [ ] RFC 4343 section 2 presentation form (encoding/decoding)
- [ ] DNSSEC canonical form
- [ ] Label constructor restricting size to 63 octets
### To-do
- [ ] Unit tests for everything in `dns::hp`
- [x] Fix zero-label case for `impl fmt::Show for Name` (should output ".")
- [ ] Presentation form
  - [x] Encoding
  - [ ] ~~Decoding (needs to handle 3 and 4 digit escape sequences)~~ (TODO: in "owned" implementation)
- [ ] `PartialEq`/`Eq` implementation for `Label`
  - [x] Case insensitive for `A-Z`/`a-z`
- [x] DNSSEC canonical form and ordering for `Name` and `Label` (see [RFC4034](https://tools.ietf.org/html/rfc4034#section-6))
  - [x] `Name` implementation
  - [x] `Label` implementation (should order case-sensitively)

Ref: oko/rust-dns#13
